### PR TITLE
Add support for SCSS imports in vue files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-  const SUPPORTED_LANGUAGES = ['scss', 'sass'];
+  const SUPPORTED_LANGUAGES = ['scss', 'sass', 'vue'];
 
   function getAliasConfig(): Record<string, string> {
     return (


### PR DESCRIPTION
In this project, styles from Vue have to be moved to a separate file due to the specific structure of style management. I suggest adding a Vue extension for convenient transition to the imported file.
There is one case left. If there are two `<style>`  blocks in the vue file:
```vue
<style lang="scss" scoped>
@import ‘@app/assets/styles/modules/fieldMap/main’;
</style>

<style lang="scss">
@import ‘@app/assets/styles/shepherd’;
@import ‘@app/assets/styles/modules/fieldMap/main/global’;
</style>
```
the files imported in the first block will not open, although the links are formed correctly according to the logs.
If you replace
```javascript
return new vscode.Location(
    vscode.Uri.file(targetFile),
    new vscode.Position(0, 0),
);
```
with this
```javascript
vscode.workspace
.openTextDocument(vscode.Uri.file(targetFile))
.then(doc => {
   vscode.window.showTextDocument(doc, { preview: false });
});
```
The file opens, but with ctrl+hover