### PR TITLE
chore: Bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.1] – 2025-01-XX
+
+### Changed
+
+- Updated VS Code engine requirement compatibility
+
+---
+
 ## [1.1.0] – 2025-01-XX
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SCSS Alias",
   "description": "Visual Studio Code extension, click-to-go SCSS import/alias resolver for @use/@import syntax.",
   "main": "./dist/extension.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "wanderlima",
   "engines": {
     "vscode": "^1.70.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps extension to 1.1.1 and updates changelog to note VS Code engine compatibility requirement update.
> 
> - **Release**:
>   - Bump version in `package.json` from `1.1.0` to `1.1.1`.
> - **Changelog**:
>   - Add `1.1.1` entry noting updated VS Code engine requirement compatibility in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14a446aaa8678ed364f5ae02602fe862f408f3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->